### PR TITLE
Changed example systemd unitfile so that systemd will not assume that the service has failed when it forks

### DIFF
--- a/universal-bison.service
+++ b/universal-bison.service
@@ -5,6 +5,7 @@ After=syslog.target network.target
 [Service]
 User=universal
 Restart=always
+Type=forking
 ExecStart=/opt/universal/bin/universal-sub-xpubxsub tcp://pubsub.ndovloket.nl:7658 tcp://0.0.0.0:7658
 
 [Install]


### PR DESCRIPTION
Currently, there is no `Type` directive in the example unit file.

This causes systemd to believe that the service has failed to start, when in fact it has forked to the background.

The commit in this PR fixes this by adding a `Type` directive and setting it to `forking`.